### PR TITLE
Minor a11y fix to add <main> tag to article body

### DIFF
--- a/essays/the-small-web/index.html
+++ b/essays/the-small-web/index.html
@@ -14,7 +14,7 @@
 		<link rel="alternate" type="application/rss+xml" title="Neustadt.fr RSS Feed" href="../../rss.xml" />
 	</head>
   <body>
-	<div id="wrapper">
+	<main id="wrapper">
 	<article>
 		<header>
 		<h1>Rediscovering the Small Web <img src="globe.gif" alt="" /></h1>
@@ -406,6 +406,6 @@
 		<a href="../../license.txt"><img src="../../img/publicdomain.png" alt="CC0 Public Domain Logo" /></a><br /> <a href="https://neustadt.fr/essays/the-small-web/">Rediscovering the Small Web</a>, written by Parimal Satyal on 25 May 2020 and published on <a href="https://neustadt.fr">Neustadt.fr</a>. This text is in the public domain with a <a href="../../license.txt">CC0 1.0 Universal license</a>; you are free to do whatever you want with it (obviously doesn't apply to the websites and resources I've linked to, or the logos and graphics in the background). A link back is nice but not required. </p>
 
 		<span class="return-end">← <a href="../../">back home</a></span>
-	</div>
+	</main>
 </body>
 </html>


### PR DESCRIPTION
Hey, I ran Equal Access Accessibility Checker on your article The Small Web while I was reading it out of mild curiosity an saw a violation. It was a fast enough change to fix quickly, so, if you so desire, here it is.